### PR TITLE
ignoring deprecation warnings

### DIFF
--- a/Cognito/AWSCognito.m
+++ b/Cognito/AWSCognito.m
@@ -224,7 +224,11 @@ static AWSCognitoSyncPlatform _pushPlatform;
             AWSCognitoSyncRegisterDeviceResponse* response = task.result;
             keychain[[AWSCognitoUtil deviceIdKey:_pushPlatform]] = response.deviceId;
             keychain[[AWSCognitoUtil deviceIdentityKey:_pushPlatform]] = self.cognitoCredentialsProvider.identityId;
-            [keychain synchronize];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            if ([UICKeyChainStore instancesRespondToSelector:@selector(synchronize)])
+                 [keychain synchronize];
+#pragma clang diagnostic pop
             [self setDeviceId:response.deviceId];
             return [BFTask taskWithResult:response.deviceId];
         }


### PR DESCRIPTION
`synchronize` deprecated in UICKeyChainStore 2.0.0 https://github.com/kishikawakatsumi/UICKeyChainStore/releases/tag/v2.0.0

There's no replacement, the function is simply no longer needed. Since the [aws-sdk-ios Podfile](https://github.com/aws/aws-sdk-ios/blob/master/AWSiOSSDKv2.podspec) specifies the dependency as *< 3.0*, it still needs to be called here, if present.
